### PR TITLE
feat(utilities): SQLiteDatabase wrapper + CryptoHelper (iPhone backup crypto)

### DIFF
--- a/CallLogCleaner/Utilities/CryptoHelper.swift
+++ b/CallLogCleaner/Utilities/CryptoHelper.swift
@@ -1,0 +1,152 @@
+import Foundation
+import CommonCrypto
+
+enum CryptoError: Error {
+    case keyDerivationFailed
+    case keyUnwrapFailed
+    case decryptionFailed
+    case encryptionFailed
+    case invalidInput
+}
+
+enum CryptoHelper {
+
+    // MARK: - PBKDF2 Two-Stage Key Derivation
+
+    /// Derives the backup KEK using Apple's two-stage PBKDF2:
+    /// Stage 1: PBKDF2-SHA256(password, dpsl, dpic) → intermediate key
+    /// Stage 2: PBKDF2-SHA1(intermediate, salt, iter) → KEK
+    static func deriveBackupKey(password: String, dpsl: Data, dpic: Int,
+                                salt: Data, iter: Int) throws -> Data {
+        guard let passwordData = password.data(using: .utf8) else {
+            throw CryptoError.invalidInput
+        }
+
+        // Stage 1: PBKDF2-SHA256
+        var stage1Key = Data(count: 32)
+        let stage1Result = stage1Key.withUnsafeMutableBytes { stage1Ptr -> Int32 in
+            dpsl.withUnsafeBytes { dpslPtr -> Int32 in
+                passwordData.withUnsafeBytes { passPtr -> Int32 in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passPtr.baseAddress?.assumingMemoryBound(to: Int8.self),
+                        passwordData.count,
+                        dpslPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        dpsl.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        UInt32(dpic),
+                        stage1Ptr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        32
+                    )
+                }
+            }
+        }
+        guard stage1Result == kCCSuccess else { throw CryptoError.keyDerivationFailed }
+
+        // Stage 2: PBKDF2-SHA1
+        var kek = Data(count: 32)
+        let stage2Result = kek.withUnsafeMutableBytes { kekPtr -> Int32 in
+            salt.withUnsafeBytes { saltPtr -> Int32 in
+                stage1Key.withUnsafeBytes { s1Ptr -> Int32 in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        s1Ptr.baseAddress?.assumingMemoryBound(to: Int8.self),
+                        stage1Key.count,
+                        saltPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                        UInt32(iter),
+                        kekPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        32
+                    )
+                }
+            }
+        }
+        guard stage2Result == kCCSuccess else { throw CryptoError.keyDerivationFailed }
+        return kek
+    }
+
+    // MARK: - RFC 3394 AES Key Unwrap
+
+    static func aesKeyUnwrap(wrappedKey: Data, kek: Data) throws -> Data {
+        let wrappedKeyLen = wrappedKey.count
+        guard wrappedKeyLen >= 16 else { throw CryptoError.invalidInput }
+        let unwrappedLen = wrappedKeyLen - 8
+        var result = Data(count: unwrappedLen)
+        var outLen = unwrappedLen
+
+        let status = result.withUnsafeMutableBytes { resultPtr -> Int32 in
+            wrappedKey.withUnsafeBytes { wrappedPtr -> Int32 in
+                kek.withUnsafeBytes { kekPtr -> Int32 in
+                    CCSymmetricKeyUnwrap(
+                        CCWrappingAlgorithm(kCCWRAPAES),
+                        CCrfc3394_iv, CCrfc3394_ivLen,
+                        kekPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        kek.count,
+                        wrappedPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        wrappedKeyLen,
+                        resultPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        &outLen
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else { throw CryptoError.keyUnwrapFailed }
+        return result.prefix(outLen)
+    }
+
+    // MARK: - AES-256-CBC (null IV)
+
+    static func aesDecrypt(data: Data, key: Data) throws -> Data {
+        return try aesCrypt(data: data, key: key, operation: CCOperation(kCCDecrypt))
+    }
+
+    static func aesEncrypt(data: Data, key: Data) throws -> Data {
+        return try aesCrypt(data: data, key: key, operation: CCOperation(kCCEncrypt))
+    }
+
+    private static func aesCrypt(data: Data, key: Data, operation: CCOperation) throws -> Data {
+        let iv = Data(count: kCCBlockSizeAES128)  // null IV
+        let bufferSize = data.count + kCCBlockSizeAES128
+        var outBuffer = Data(count: bufferSize)
+        var outLen = 0
+
+        let status = outBuffer.withUnsafeMutableBytes { outPtr -> CCCryptorStatus in
+            data.withUnsafeBytes { dataPtr -> CCCryptorStatus in
+                key.withUnsafeBytes { keyPtr -> CCCryptorStatus in
+                    iv.withUnsafeBytes { ivPtr -> CCCryptorStatus in
+                        CCCrypt(
+                            operation,
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyPtr.baseAddress, key.count,
+                            ivPtr.baseAddress,
+                            dataPtr.baseAddress, data.count,
+                            outPtr.baseAddress, bufferSize,
+                            &outLen
+                        )
+                    }
+                }
+            }
+        }
+        guard status == kCCSuccess else {
+            throw operation == CCOperation(kCCDecrypt) ? CryptoError.decryptionFailed : CryptoError.encryptionFailed
+        }
+        return outBuffer.prefix(outLen)
+    }
+
+    // MARK: - SHA1
+
+    static func sha1(_ string: String) -> String {
+        guard let data = string.data(using: .utf8) else { return "" }
+        return sha1(data)
+    }
+
+    static func sha1(_ data: Data) -> String {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes { ptr in
+            _ = CC_SHA1(ptr.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/CallLogCleaner/Utilities/SQLiteDatabase.swift
+++ b/CallLogCleaner/Utilities/SQLiteDatabase.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SQLite3
+
+// SQLITE_TRANSIENT is a C macro not available in Swift
+private let SQLITE_TRANSIENT_FUNC = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+enum SQLiteError: Error {
+    case openFailed(String)
+    case prepareFailed(String)
+    case stepFailed(String)
+    case bindFailed
+    case transactionFailed(String)
+}
+
+class SQLiteDatabase {
+    private var db: OpaquePointer?
+    private let path: String
+
+    init(path: String, readonly: Bool = true) throws {
+        self.path = path
+        let flags = readonly ? SQLITE_OPEN_READONLY : (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE)
+        let result = sqlite3_open_v2(path, &db, flags, nil)
+        guard result == SQLITE_OK else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            throw SQLiteError.openFailed(msg)
+        }
+    }
+
+    deinit { close() }
+
+    func close() {
+        if db != nil {
+            sqlite3_close(db)
+            db = nil
+        }
+    }
+
+    func query(_ sql: String, bind: [Any] = []) throws -> [[String: Any]] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw SQLiteError.prepareFailed(lastError())
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        try bindParameters(stmt: stmt, params: bind)
+
+        var rows: [[String: Any]] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            var row: [String: Any] = [:]
+            let columnCount = sqlite3_column_count(stmt)
+            for i in 0..<columnCount {
+                let name = String(cString: sqlite3_column_name(stmt, i))
+                row[name] = columnValue(stmt: stmt, index: i)
+            }
+            rows.append(row)
+        }
+        return rows
+    }
+
+    func execute(_ sql: String, bind: [Any] = []) throws {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw SQLiteError.prepareFailed(lastError())
+        }
+        defer { sqlite3_finalize(stmt) }
+        try bindParameters(stmt: stmt, params: bind)
+        let result = sqlite3_step(stmt)
+        guard result == SQLITE_DONE || result == SQLITE_ROW else {
+            throw SQLiteError.stepFailed(lastError())
+        }
+    }
+
+    func executeInTransaction(_ block: () throws -> Void) throws {
+        try execute("BEGIN TRANSACTION")
+        do {
+            try block()
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func bindParameters(stmt: OpaquePointer?, params: [Any]) throws {
+        for (i, param) in params.enumerated() {
+            let idx = Int32(i + 1)
+            let result: Int32
+            switch param {
+            case let v as Int:
+                result = sqlite3_bind_int64(stmt, idx, Int64(v))
+            case let v as Int64:
+                result = sqlite3_bind_int64(stmt, idx, v)
+            case let v as Double:
+                result = sqlite3_bind_double(stmt, idx, v)
+            case let v as String:
+                result = sqlite3_bind_text(stmt, idx, v, -1, SQLITE_TRANSIENT_FUNC)
+            case let v as Data:
+                result = v.withUnsafeBytes { ptr in
+                    sqlite3_bind_blob(stmt, idx, ptr.baseAddress, Int32(v.count), SQLITE_TRANSIENT_FUNC)
+                }
+            case is NSNull:
+                result = sqlite3_bind_null(stmt, idx)
+            default:
+                result = sqlite3_bind_null(stmt, idx)
+            }
+            guard result == SQLITE_OK else { throw SQLiteError.bindFailed }
+        }
+    }
+
+    private func columnValue(stmt: OpaquePointer?, index: Int32) -> Any {
+        switch sqlite3_column_type(stmt, index) {
+        case SQLITE_INTEGER:
+            return sqlite3_column_int64(stmt, index)
+        case SQLITE_FLOAT:
+            return sqlite3_column_double(stmt, index)
+        case SQLITE_TEXT:
+            return String(cString: sqlite3_column_text(stmt, index))
+        case SQLITE_BLOB:
+            if let ptr = sqlite3_column_blob(stmt, index) {
+                let count = Int(sqlite3_column_bytes(stmt, index))
+                return Data(bytes: ptr, count: count)
+            }
+            return Data()
+        case SQLITE_NULL:
+            return NSNull()
+        default:
+            return NSNull()
+        }
+    }
+
+    private func lastError() -> String {
+        return String(cString: sqlite3_errmsg(db))
+    }
+}


### PR DESCRIPTION
## Summary
- Zero-dependency SQLite3 C-API wrapper with query, execute, and transaction support; fixes the `SQLITE_TRANSIENT` Swift bridging gap
- Full cryptographic toolkit for encrypted iPhone backup decryption: two-stage PBKDF2 (SHA-256 → SHA-1), RFC 3394 AES key unwrap, AES-256-CBC encrypt/decrypt (null IV, PKCS7), SHA-1 file-ID hashing

## Test plan
- [ ] `SQLiteDatabase` opens a read-only DB and returns rows correctly
- [ ] `SQLiteDatabase` executes writes inside a transaction and rolls back on error
- [ ] `CryptoHelper.deriveBackupKey` produces correct KEK (verifiable against known BackupKeyBag test vector)
- [ ] `CryptoHelper.aesKeyUnwrap` unwraps a known class key successfully
- [ ] `CryptoHelper.aesDecrypt` / `aesEncrypt` round-trip produces identical plaintext
- [ ] `CryptoHelper.sha1` matches `SHA1("HomeDomain-Library/CallHistoryDB/CallHistory.storedata")` expected hex

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive encryption and cryptographic security utilities including password-based key derivation, secure data encryption/decryption, cryptographic key unwrapping, and hashing functions with robust error handling and validation
  * Added SQLite database management layer providing prepared statement support, automatic parameter binding, typed result mapping, and transactional support for reliable and consistent database operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->