### PR TITLE
feat(models): CallRecord, BackupInfo, FilterCriteria + CallHistoryService

### DIFF
--- a/CallLogCleaner/Models/BackupInfo.swift
+++ b/CallLogCleaner/Models/BackupInfo.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct BackupInfo: Identifiable, Equatable {
+    let id: String           // backup UDID folder name
+    let path: URL
+    let deviceName: String
+    let deviceModel: String  // e.g. "iPhone15,2"
+    let phoneNumber: String
+    let iOSVersion: String
+    let lastBackupDate: Date
+    let isEncrypted: Bool
+    let backupSize: Int64    // bytes
+
+    static func == (lhs: BackupInfo, rhs: BackupInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    var formattedSize: String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: backupSize)
+    }
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: lastBackupDate)
+    }
+}

--- a/CallLogCleaner/Models/CallRecord.swift
+++ b/CallLogCleaner/Models/CallRecord.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct CallRecord: Identifiable, Equatable {
+    let id: Int64
+    let date: Date
+    let address: String
+    let name: String?
+    let duration: TimeInterval
+    let callType: CallType
+    let direction: CallDirection
+    let isAnswered: Bool
+    let isoCountryCode: String?
+    var isSelected: Bool = false
+
+    static func == (lhs: CallRecord, rhs: CallRecord) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    var formattedDuration: String {
+        if duration < 1 { return "—" }
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    var displayName: String {
+        name?.isEmpty == false ? name! : address
+    }
+}
+
+enum CallType: Int, CaseIterable {
+    case phone = 1
+    case faceTimeVideo = 8
+    case faceTimeAudio = 16
+
+    var label: String {
+        switch self {
+        case .phone: return "Phone"
+        case .faceTimeVideo: return "FaceTime Video"
+        case .faceTimeAudio: return "FaceTime Audio"
+        }
+    }
+}
+
+enum CallDirection: Equatable {
+    case incoming
+    case outgoing
+}

--- a/CallLogCleaner/Models/FilterCriteria.swift
+++ b/CallLogCleaner/Models/FilterCriteria.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct FilterCriteria {
+    var searchText: String = ""
+    var dateFrom: Date? = nil
+    var dateTo: Date? = nil
+    var callTypes: Set<CallType> = []
+    var direction: DirectionFilter = .all
+    var showMissedOnly: Bool = false
+
+    enum DirectionFilter: String, CaseIterable {
+        case all = "All"
+        case incoming = "Incoming"
+        case outgoing = "Outgoing"
+    }
+
+    var isActive: Bool {
+        !searchText.isEmpty || dateFrom != nil || dateTo != nil
+        || !callTypes.isEmpty || direction != .all || showMissedOnly
+    }
+
+    func matches(_ record: CallRecord) -> Bool {
+        if !searchText.isEmpty {
+            let lower = searchText.lowercased()
+            let matchesAddress = record.address.lowercased().contains(lower)
+            let matchesName = record.name?.lowercased().contains(lower) ?? false
+            if !matchesAddress && !matchesName { return false }
+        }
+        if let from = dateFrom, record.date < from { return false }
+        if let to = dateTo, record.date > to { return false }
+        if !callTypes.isEmpty && !callTypes.contains(record.callType) { return false }
+        switch direction {
+        case .incoming: if record.direction != .incoming { return false }
+        case .outgoing: if record.direction != .outgoing { return false }
+        case .all: break
+        }
+        if showMissedOnly && record.isAnswered { return false }
+        return true
+    }
+
+    mutating func reset() {
+        searchText = ""
+        dateFrom = nil
+        dateTo = nil
+        callTypes = []
+        direction = .all
+        showMissedOnly = false
+    }
+}

--- a/CallLogCleaner/Services/CallHistoryService.swift
+++ b/CallLogCleaner/Services/CallHistoryService.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+// Core Data epoch: Jan 1, 2001
+private let coreDataEpochOffset: TimeInterval = 978307200
+
+class CallHistoryService {
+    private var db: SQLiteDatabase
+
+    init(dbPath: URL) throws {
+        db = try SQLiteDatabase(path: dbPath.path, readonly: false)
+    }
+
+    deinit { db.close() }
+
+    func loadAllRecords() throws -> [CallRecord] {
+        let rows = try db.query("""
+            SELECT Z_PK, ZDATE, ZADDRESS, ZNAME, ZDURATION,
+                   ZCALLTYPE, ZORIGINATED, ZANSWERED, ZISO_COUNTRY_CODE
+            FROM ZCALLRECORD
+            ORDER BY ZDATE DESC
+            """)
+
+        return rows.compactMap { row -> CallRecord? in
+            guard let pk = row["Z_PK"] as? Int64 else { return nil }
+
+            let cdDate = row["ZDATE"] as? Double ?? 0
+            let date = Date(timeIntervalSince1970: cdDate + coreDataEpochOffset)
+
+            let address = row["ZADDRESS"] as? String ?? ""
+            let name = row["ZNAME"] as? String
+            let duration = row["ZDURATION"] as? Double ?? 0
+
+            let typeRaw = Int(row["ZCALLTYPE"] as? Int64 ?? 1)
+            let callType = CallType(rawValue: typeRaw) ?? .phone
+
+            let originated = (row["ZORIGINATED"] as? Int64 ?? 0) == 1
+            let direction: CallDirection = originated ? .outgoing : .incoming
+
+            let answered = (row["ZANSWERED"] as? Int64 ?? 0) == 1
+            let country = row["ZISO_COUNTRY_CODE"] as? String
+
+            return CallRecord(
+                id: pk,
+                date: date,
+                address: address,
+                name: (name?.isEmpty == false) ? name : nil,
+                duration: duration,
+                callType: callType,
+                direction: direction,
+                isAnswered: answered,
+                isoCountryCode: country
+            )
+        }
+    }
+
+    func deleteRecords(ids: [Int64]) throws {
+        guard !ids.isEmpty else { return }
+        try db.executeInTransaction {
+            // Build IN clause
+            let placeholders = ids.map { _ in "?" }.joined(separator: ",")
+
+            // Delete related handles
+            try db.execute(
+                "DELETE FROM Z_2REMOTEPARTICIPANTHANDLES WHERE Z_2CALLRECORDS IN (\(placeholders))",
+                bind: ids.map { $0 as Any }
+            )
+
+            // Delete call records
+            try db.execute(
+                "DELETE FROM ZCALLRECORD WHERE Z_PK IN (\(placeholders))",
+                bind: ids.map { $0 as Any }
+            )
+
+            // Clean orphaned handles
+            try? db.execute("""
+                DELETE FROM ZHANDLE WHERE Z_PK NOT IN (
+                    SELECT DISTINCT Z_2REMOTEPARTICIPANTHANDLES FROM Z_2REMOTEPARTICIPANTHANDLES
+                )
+                """)
+        }
+    }
+
+    func recordCount() throws -> Int {
+        let rows = try db.query("SELECT COUNT(*) as cnt FROM ZCALLRECORD")
+        return Int(rows.first?["cnt"] as? Int64 ?? 0)
+    }
+}


### PR DESCRIPTION
## Summary
- `CallRecord` struct with `CallType` / `CallDirection` enums and formatted display helpers
- `BackupInfo` struct with device metadata and `formattedSize` helper
- `FilterCriteria` with composable `matches(_:)` predicate covering text search, date range, call type, direction, and missed-only filter
- `CallHistoryService` reads all `ZCALLRECORD` rows (Core Data epoch → `Date`) and deletes records in a transaction, cleaning up related handle rows

## Test plan
- [ ] `CallHistoryService.loadAllRecords()` returns correct dates (epoch offset verified)
- [ ] `CallHistoryService.deleteRecords(ids:)` removes rows and matching handle rows
- [ ] `FilterCriteria.matches` correctly passes/rejects records for each filter axis
- [ ] `BackupInfo.formattedSize` formats bytes into human-readable GB/MB

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)