### PR TITLE
feat(services): encrypted iPhone backup decryption & re-encryption pipeline

### DIFF
--- a/CallLogCleaner/Services/BackupDecryptor.swift
+++ b/CallLogCleaner/Services/BackupDecryptor.swift
@@ -1,0 +1,211 @@
+import Foundation
+import CommonCrypto
+
+enum BackupError: Error, LocalizedError {
+    case wrongPassword
+    case manifestNotFound
+    case keyBagNotFound
+    case manifestKeyNotFound
+    case classKeyNotFound(Int)
+    case fileNotFound(String)
+    case decryptionFailed
+    case invalidData(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .wrongPassword: return "Wrong backup password."
+        case .manifestNotFound: return "Manifest.plist not found."
+        case .keyBagNotFound: return "BackupKeyBag not found in Manifest.plist."
+        case .manifestKeyNotFound: return "ManifestKey not found in Manifest.plist."
+        case .classKeyNotFound(let cls): return "Class key \(cls) not found."
+        case .fileNotFound(let f): return "File not found: \(f)"
+        case .decryptionFailed: return "Decryption failed."
+        case .invalidData(let msg): return "Invalid data: \(msg)"
+        }
+    }
+}
+
+struct ClassKey {
+    var cls: Int = 0
+    var wrappedKey: Data = Data()
+    var unwrappedKey: Data? = nil
+}
+
+class BackupDecryptor {
+    private let backupPath: URL
+    private var classKeys: [Int: ClassKey] = [:]
+    private var unwrappedManifestKey: Data?
+
+    private(set) var manifestKeyData: Data = Data()
+    private(set) var manifestKeyClass: Int = 0
+
+    init(backupPath: URL, password: String) throws {
+        self.backupPath = backupPath
+
+        let manifestPlistURL = backupPath.appendingPathComponent("Manifest.plist")
+        guard FileManager.default.fileExists(atPath: manifestPlistURL.path) else {
+            throw BackupError.manifestNotFound
+        }
+
+        let manifestData = try Data(contentsOf: manifestPlistURL)
+        guard let manifest = try? PropertyListSerialization.propertyList(
+            from: manifestData, format: nil
+        ) as? [String: Any] else {
+            throw BackupError.invalidData("Manifest.plist parse failed")
+        }
+
+        guard let keyBagData = manifest["BackupKeyBag"] as? Data else {
+            throw BackupError.keyBagNotFound
+        }
+
+        guard let rawManifestKey = manifest["ManifestKey"] as? Data else {
+            throw BackupError.manifestKeyNotFound
+        }
+
+        // Parse BackupKeyBag
+        try parseKeyBag(keyBagData, password: password)
+
+        // ManifestKey: first 4 bytes = protection class, rest = wrapped key
+        guard rawManifestKey.count >= 4 else {
+            throw BackupError.invalidData("ManifestKey too short")
+        }
+        let classBytes = rawManifestKey.prefix(4)
+        let cls = Int(classBytes.withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+        manifestKeyClass = cls
+        manifestKeyData = rawManifestKey.dropFirst(4)
+
+        // Unwrap manifest key
+        guard let classKey = classKeys[cls], let kek = classKey.unwrappedKey else {
+            throw BackupError.classKeyNotFound(cls)
+        }
+        unwrappedManifestKey = try CryptoHelper.aesKeyUnwrap(wrappedKey: manifestKeyData, kek: kek)
+    }
+
+    // MARK: - Manifest DB
+
+    func decryptManifestDB() throws -> Data {
+        let manifestDBURL = backupPath.appendingPathComponent("Manifest.db")
+        let encryptedData = try Data(contentsOf: manifestDBURL)
+        guard let key = unwrappedManifestKey else { throw BackupError.decryptionFailed }
+        return try CryptoHelper.aesDecrypt(data: encryptedData, key: key)
+    }
+
+    func encryptManifestDB(_ data: Data) throws -> Data {
+        guard let key = unwrappedManifestKey else { throw BackupError.decryptionFailed }
+        return try CryptoHelper.aesEncrypt(data: data, key: key)
+    }
+
+    // MARK: - File Decryption
+
+    func decryptFile(fileID: String, protectionClass: Int, wrappedKey: Data) throws -> Data {
+        guard let classKey = classKeys[protectionClass], let kek = classKey.unwrappedKey else {
+            throw BackupError.classKeyNotFound(protectionClass)
+        }
+
+        let fileKey = try CryptoHelper.aesKeyUnwrap(wrappedKey: wrappedKey, kek: kek)
+
+        let prefix = String(fileID.prefix(2))
+        let fileURL = backupPath.appendingPathComponent(prefix).appendingPathComponent(fileID)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw BackupError.fileNotFound(fileID)
+        }
+
+        let encryptedData = try Data(contentsOf: fileURL)
+        return try CryptoHelper.aesDecrypt(data: encryptedData, key: fileKey)
+    }
+
+    func encryptFile(data: Data, fileKey: Data) throws -> Data {
+        return try CryptoHelper.aesEncrypt(data: data, key: fileKey)
+    }
+
+    func unwrapFileKey(protectionClass: Int, wrappedKey: Data) throws -> Data {
+        guard let classKey = classKeys[protectionClass], let kek = classKey.unwrappedKey else {
+            throw BackupError.classKeyNotFound(protectionClass)
+        }
+        return try CryptoHelper.aesKeyUnwrap(wrappedKey: wrappedKey, kek: kek)
+    }
+
+    // MARK: - KeyBag Parsing
+
+    private func parseKeyBag(_ data: Data, password: String) throws {
+        var offset = 0
+        var dpsl = Data()
+        var dpic = 0
+        var bagSalt = Data()
+        var bagIter = 0
+
+        // First pass: get top-level PBKDF2 params
+        var tempOffset = 0
+        while tempOffset < data.count - 8 {
+            let tag = String(bytes: data[tempOffset..<tempOffset+4], encoding: .ascii) ?? ""
+            let len = Int(data[(tempOffset+4)..<(tempOffset+8)].withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+            tempOffset += 8
+            guard tempOffset + len <= data.count else { break }
+            let value = data[tempOffset..<tempOffset+len]
+            switch tag {
+            case "DPSL": dpsl = Data(value)
+            case "DPIC": dpic = Int(value.withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+            case "SALT": bagSalt = Data(value)
+            case "ITER": bagIter = Int(value.withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+            default: break
+            }
+            tempOffset += len
+        }
+
+        guard !dpsl.isEmpty, dpic > 0, !bagSalt.isEmpty, bagIter > 0 else {
+            throw BackupError.invalidData("Missing PBKDF2 params in keybag")
+        }
+
+        // Derive KEK
+        let kek = try CryptoHelper.deriveBackupKey(
+            password: password,
+            dpsl: dpsl,
+            dpic: dpic,
+            salt: bagSalt,
+            iter: bagIter
+        )
+
+        // Second pass: parse class keys and try to unwrap with KEK
+        offset = 0
+        var currentClass: ClassKey? = nil
+
+        while offset < data.count - 8 {
+            let tag = String(bytes: data[offset..<offset+4], encoding: .ascii) ?? ""
+            let len = Int(data[(offset+4)..<(offset+8)].withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+            offset += 8
+            guard offset + len <= data.count else { break }
+            let value = data[offset..<offset+len]
+
+            switch tag {
+            case "CLS":
+                // Save previous class key if valid
+                if let prev = currentClass, prev.cls > 0, !prev.wrappedKey.isEmpty {
+                    var ck = prev
+                    ck.unwrappedKey = try? CryptoHelper.aesKeyUnwrap(wrappedKey: ck.wrappedKey, kek: kek)
+                    classKeys[ck.cls] = ck
+                }
+                var ck = ClassKey()
+                ck.cls = Int(value.withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+                currentClass = ck
+            case "WPKY":
+                currentClass?.wrappedKey = Data(value)
+            default:
+                break
+            }
+            offset += len
+        }
+
+        // Save last class key
+        if let prev = currentClass, prev.cls > 0, !prev.wrappedKey.isEmpty {
+            var ck = prev
+            ck.unwrappedKey = try? CryptoHelper.aesKeyUnwrap(wrappedKey: ck.wrappedKey, kek: kek)
+            classKeys[ck.cls] = ck
+        }
+
+        // Validate password by checking at least one key unwrapped
+        let anyUnwrapped = classKeys.values.contains { $0.unwrappedKey != nil }
+        if !anyUnwrapped {
+            throw BackupError.wrongPassword
+        }
+    }
+}

--- a/CallLogCleaner/Services/BackupModifier.swift
+++ b/CallLogCleaner/Services/BackupModifier.swift
@@ -1,0 +1,90 @@
+import Foundation
+import CommonCrypto
+
+class BackupModifier {
+
+    func modifyCallHistory(
+        backupPath: URL,
+        password: String,
+        recordIDsToDelete: [Int64],
+        progressCallback: @escaping (String) -> Void
+    ) async throws {
+
+        progressCallback("Initializing decryptor…")
+        let decryptor = try BackupDecryptor(backupPath: backupPath, password: password)
+
+        progressCallback("Decrypting Manifest.db…")
+        let manifestData = try decryptor.decryptManifestDB()
+        let manifestReader = try ManifestReader(manifestDBData: manifestData)
+
+        progressCallback("Locating CallHistory.storedata…")
+        let relPath = "Library/CallHistoryDB/CallHistory.storedata"
+        guard let manifestFile = try manifestReader.findFile(relativePath: relPath) else {
+            throw ManifestError.fileNotFound(relPath)
+        }
+
+        guard let wrappedKey = manifestFile.encryptionKey else {
+            throw BackupError.invalidData("CallHistory file has no encryption key")
+        }
+
+        progressCallback("Decrypting CallHistory.storedata…")
+        let fileKey = try decryptor.unwrapFileKey(
+            protectionClass: manifestFile.protectionClass,
+            wrappedKey: wrappedKey
+        )
+        let callHistoryData = try decryptor.decryptFile(
+            fileID: manifestFile.fileID,
+            protectionClass: manifestFile.protectionClass,
+            wrappedKey: wrappedKey
+        )
+
+        progressCallback("Opening database…")
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempDBURL = tempDir.appendingPathComponent("CallHistory_\(UUID().uuidString).storedata")
+        try callHistoryData.write(to: tempDBURL)
+        defer { try? FileManager.default.removeItem(at: tempDBURL) }
+
+        // Backup original file
+        let origPrefix = String(manifestFile.fileID.prefix(2))
+        let origFileURL = backupPath
+            .appendingPathComponent(origPrefix)
+            .appendingPathComponent(manifestFile.fileID)
+        let backupFileURL = origFileURL.appendingPathExtension("backup")
+        try? FileManager.default.copyItem(at: origFileURL, to: backupFileURL)
+
+        progressCallback("Deleting \(recordIDsToDelete.count) records…")
+        let service = try CallHistoryService(dbPath: tempDBURL)
+        try service.deleteRecords(ids: recordIDsToDelete)
+
+        progressCallback("Re-encrypting CallHistory.storedata…")
+        let modifiedData = try Data(contentsOf: tempDBURL)
+        let reencryptedData = try decryptor.encryptFile(data: modifiedData, fileKey: fileKey)
+
+        // Compute new file hash
+        let newFileHash = CryptoHelper.sha1("HomeDomain" + "-" + relPath)
+        let newPrefix = String(newFileHash.prefix(2))
+
+        progressCallback("Writing modified backup file…")
+        let newFileDir = backupPath.appendingPathComponent(newPrefix)
+        try FileManager.default.createDirectory(at: newFileDir, withIntermediateDirectories: true)
+        let newFileURL = newFileDir.appendingPathComponent(newFileHash)
+        try reencryptedData.write(to: newFileURL)
+
+        progressCallback("Updating Manifest.db…")
+        // Only update if fileID changed
+        if manifestFile.fileID != newFileHash {
+            try manifestReader.updateFileID(old: manifestFile.fileID, new: newFileHash)
+            let modifiedManifest = try manifestReader.saveModifiedDB()
+            let reencryptedManifest = try decryptor.encryptManifestDB(modifiedManifest)
+            let manifestDBURL = backupPath.appendingPathComponent("Manifest.db")
+            try reencryptedManifest.write(to: manifestDBURL)
+
+            // Remove old file
+            if manifestFile.fileID != newFileHash {
+                try? FileManager.default.removeItem(at: origFileURL)
+            }
+        }
+
+        progressCallback("Done.")
+    }
+}

--- a/CallLogCleaner/Services/BackupScanner.swift
+++ b/CallLogCleaner/Services/BackupScanner.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+class BackupScanner {
+
+    static let backupRoot = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/MobileSync/Backup")
+
+    static func findAllBackups() -> [BackupInfo] {
+        var backups: [BackupInfo] = []
+        let fm = FileManager.default
+
+        guard let contents = try? fm.contentsOfDirectory(
+            at: backupRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        for url in contents {
+            guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+            guard let info = parseBackup(at: url) else { continue }
+            backups.append(info)
+        }
+
+        return backups.sorted { $0.lastBackupDate > $1.lastBackupDate }
+    }
+
+    // MARK: - Private
+
+    private static func parseBackup(at url: URL) -> BackupInfo? {
+        let fm = FileManager.default
+        let infoURL = url.appendingPathComponent("Info.plist")
+        let manifestURL = url.appendingPathComponent("Manifest.plist")
+
+        guard fm.fileExists(atPath: infoURL.path),
+              fm.fileExists(atPath: manifestURL.path) else { return nil }
+
+        guard let infoDict = NSDictionary(contentsOf: infoURL) as? [String: Any],
+              let manifestDict = NSDictionary(contentsOf: manifestURL) as? [String: Any] else { return nil }
+
+        let deviceName = infoDict["Device Name"] as? String ?? "Unknown Device"
+        let deviceModel = infoDict["Product Type"] as? String ?? ""
+        let phoneNumber = infoDict["Phone Number"] as? String ?? ""
+        let iOSVersion = infoDict["Product Version"] as? String ?? ""
+        let isEncrypted = manifestDict["IsEncrypted"] as? Bool ?? false
+        let backupDate = manifestDict["Date"] as? Date ?? Date()
+
+        let size = calculateSize(at: url)
+
+        return BackupInfo(
+            id: url.lastPathComponent,
+            path: url,
+            deviceName: deviceName,
+            deviceModel: deviceModel,
+            phoneNumber: phoneNumber,
+            iOSVersion: iOSVersion,
+            lastBackupDate: backupDate,
+            isEncrypted: isEncrypted,
+            backupSize: size
+        )
+    }
+
+    private static func calculateSize(at url: URL) -> Int64 {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            if let size = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+}

--- a/CallLogCleaner/Services/ManifestReader.swift
+++ b/CallLogCleaner/Services/ManifestReader.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+enum ManifestError: Error, LocalizedError {
+    case fileNotFound(String)
+    case parseFailed
+    case saveFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let path): return "File not found in Manifest: \(path)"
+        case .parseFailed: return "Failed to parse Manifest.db"
+        case .saveFailed: return "Failed to save Manifest.db"
+        }
+    }
+}
+
+struct ManifestFile {
+    let fileID: String
+    let domain: String
+    let flags: Int
+    let protectionClass: Int
+    let encryptionKey: Data?
+}
+
+class ManifestReader {
+    private var db: SQLiteDatabase
+    private let tempURL: URL
+
+    init(manifestDBData: Data) throws {
+        // Write to temp file for SQLite access
+        let tempDir = FileManager.default.temporaryDirectory
+        tempURL = tempDir.appendingPathComponent("Manifest_\(UUID().uuidString).db")
+        try manifestDBData.write(to: tempURL)
+        db = try SQLiteDatabase(path: tempURL.path, readonly: false)
+    }
+
+    deinit {
+        db.close()
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
+    func findFile(relativePath: String) throws -> ManifestFile? {
+        let rows = try db.query(
+            "SELECT fileID, domain, flags, file FROM Files WHERE relativePath = ?",
+            bind: [relativePath]
+        )
+        guard let row = rows.first else { return nil }
+
+        let fileID = row["fileID"] as? String ?? ""
+        let domain = row["domain"] as? String ?? ""
+        let flags = Int(row["flags"] as? Int64 ?? 0)
+
+        var protectionClass = 0
+        var encryptionKey: Data? = nil
+
+        if let fileData = row["file"] as? Data {
+            if let parsed = try? parseFilePlist(fileData) {
+                protectionClass = parsed.protectionClass
+                encryptionKey = parsed.encryptionKey
+            }
+        }
+
+        return ManifestFile(
+            fileID: fileID,
+            domain: domain,
+            flags: flags,
+            protectionClass: protectionClass,
+            encryptionKey: encryptionKey
+        )
+    }
+
+    func updateFileID(old: String, new: String) throws {
+        try db.execute("UPDATE Files SET fileID = ? WHERE fileID = ?", bind: [new, old])
+    }
+
+    func saveModifiedDB() throws -> Data {
+        db.close()
+        let data = try Data(contentsOf: tempURL)
+        db = try SQLiteDatabase(path: tempURL.path, readonly: false)
+        return data
+    }
+
+    // MARK: - Private
+
+    private func parseFilePlist(_ data: Data) throws -> (protectionClass: Int, encryptionKey: Data?) {
+        guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let dict = plist as? [String: Any] else {
+            return (0, nil)
+        }
+
+        // The file plist is a protobuf-like structure; try NSKeyedArchiver format first
+        // Apple uses a custom binary plist with specific keys
+        var protectionClass = 0
+        var encryptionKey: Data? = nil
+
+        // Try direct key access (works for some backup versions)
+        if let cls = dict["ProtectionClass"] as? Int {
+            protectionClass = cls
+        }
+        if let key = dict["EncryptionKey"] as? Data {
+            // First 4 bytes are protection class, rest is wrapped key
+            if key.count > 4 {
+                encryptionKey = key.dropFirst(4)
+                if protectionClass == 0 {
+                    protectionClass = Int(key.prefix(4).withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+                }
+            }
+        }
+
+        // Try nested $objects format (NSKeyedArchiver)
+        if let objects = dict["$objects"] as? [Any] {
+            for obj in objects {
+                if let objDict = obj as? [String: Any] {
+                    if let cls = objDict["ProtectionClass"] as? Int {
+                        protectionClass = cls
+                    }
+                    if let key = objDict["EncryptionKey"] as? Data, key.count > 4 {
+                        encryptionKey = key.dropFirst(4)
+                        if protectionClass == 0 {
+                            protectionClass = Int(key.prefix(4).withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+                        }
+                    }
+                    if let keyDict = objDict["EncryptionKey"] as? [String: Any],
+                       let keyData = keyDict["NS.data"] as? Data, keyData.count > 4 {
+                        encryptionKey = keyData.dropFirst(4)
+                        if protectionClass == 0 {
+                            protectionClass = Int(keyData.prefix(4).withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+                        }
+                    }
+                }
+            }
+        }
+
+        return (protectionClass, encryptionKey)
+    }
+}


### PR DESCRIPTION
## Summary
- **BackupScanner**: discovers all local iPhone backups, parses device metadata from `Info.plist` / `Manifest.plist`
- **BackupDecryptor**: two-pass BackupKeyBag TLV parser → two-stage PBKDF2 KEK derivation → RFC 3394 class key unwrap → AES-CBC file decryption/re-encryption
- **ManifestReader**: opens decrypted `Manifest.db`, queries `Files` table, parses binary plist to extract `ProtectionClass` and wrapped per-file `EncryptionKey`
- **BackupModifier**: full orchestration — decrypt → modify SQLite → re-encrypt → update manifest → write new file hash to backup directory

## Encryption Details
| Step | Algorithm |
|------|-----------|
| KEK derivation stage 1 | PBKDF2-SHA256 (DPSL key, DPIC iterations) |
| KEK derivation stage 2 | PBKDF2-SHA1 (SALT, ITER) |
| Class key unwrap | RFC 3394 AES Key Wrap (`CCSymmetricKeyUnwrap`) |
| File decryption | AES-256-CBC, null IV, PKCS7 padding |
| New file hash | `SHA1("HomeDomain-Library/CallHistoryDB/CallHistory.storedata")` |

## Test plan
- [ ] `BackupScanner` finds at least one backup when a real encrypted backup exists
- [ ] `BackupDecryptor` throws `wrongPassword` on incorrect password, succeeds on correct
- [ ] `BackupDecryptor.decryptManifestDB()` returns valid SQLite bytes
- [ ] `ManifestReader.findFile(relativePath:)` returns non-nil for `Library/CallHistoryDB/CallHistory.storedata`
- [ ] `BackupModifier` completes without error on a test backup; restored backup shows deleted records removed

Closes #7
