### PR TITLE
feat(analytics): AnalyticsEngine + full scrollable analytics dashboard

### DIFF
--- a/CallLogCleaner/Services/AnalyticsEngine.swift
+++ b/CallLogCleaner/Services/AnalyticsEngine.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+struct DailyCallCount: Identifiable {
+    let id: Date
+    let date: Date
+    let count: Int
+}
+
+struct ContactCallCount: Identifiable {
+    var id: String { name }
+    let name: String
+    let count: Int
+    let totalDuration: TimeInterval
+}
+
+struct HourlyCell: Identifiable {
+    var id: String { "\(weekday)-\(hour)" }
+    let weekday: Int  // 1=Sun … 7=Sat
+    let hour: Int     // 0–23
+    let count: Int
+}
+
+struct AnalyticsData {
+    let totalCalls: Int
+    let totalDuration: TimeInterval
+    let uniqueContacts: Int
+    let missedCallCount: Int
+    let missedCallRate: Double
+    let incomingCount: Int
+    let outgoingCount: Int
+    let avgCallDuration: TimeInterval
+
+    let dailyCounts: [DailyCallCount]
+    let topContacts: [ContactCallCount]
+    let typeDistribution: [(label: String, count: Int, color: String)]
+    let hourlyCells: [HourlyCell]
+
+    var formattedTotalDuration: String {
+        let hours = Int(totalDuration) / 3600
+        let minutes = (Int(totalDuration) % 3600) / 60
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+
+    var formattedAvgDuration: String {
+        let minutes = Int(avgCallDuration) / 60
+        let seconds = Int(avgCallDuration) % 60
+        return "\(minutes)m \(seconds)s"
+    }
+}
+
+enum TimeRange: String, CaseIterable, Identifiable {
+    case week    = "7 Days"
+    case month   = "30 Days"
+    case quarter = "90 Days"
+    case all     = "All Time"
+
+    var id: String { rawValue }
+
+    func startDate(from reference: Date = Date()) -> Date? {
+        let cal = Calendar.current
+        switch self {
+        case .week:    return cal.date(byAdding: .day, value: -7, to: reference)
+        case .month:   return cal.date(byAdding: .day, value: -30, to: reference)
+        case .quarter: return cal.date(byAdding: .day, value: -90, to: reference)
+        case .all:     return nil
+        }
+    }
+}
+
+enum AnalyticsEngine {
+    static func compute(records: [CallRecord], timeRange: TimeRange = .all) -> AnalyticsData {
+        let filtered: [CallRecord]
+        if let start = timeRange.startDate() {
+            filtered = records.filter { $0.date >= start }
+        } else {
+            filtered = records
+        }
+
+        let total = filtered.count
+        let totalDuration = filtered.reduce(0) { $0 + $1.duration }
+        let missed = filtered.filter { !$0.isAnswered }.count
+        let incoming = filtered.filter { $0.direction == .incoming }.count
+        let outgoing = filtered.filter { $0.direction == .outgoing }.count
+
+        let uniqueContacts = Set(filtered.map { $0.displayName }).count
+
+        let avgDuration: TimeInterval
+        let answeredCalls = filtered.filter { $0.isAnswered && $0.duration > 0 }
+        avgDuration = answeredCalls.isEmpty ? 0 : answeredCalls.reduce(0) { $0 + $1.duration } / Double(answeredCalls.count)
+
+        // Daily counts
+        let dailyCounts = computeDailyCounts(filtered, timeRange: timeRange)
+
+        // Top contacts (by call count, max 10)
+        let contactGroups = Dictionary(grouping: filtered, by: { $0.displayName })
+        let topContacts = contactGroups
+            .map { (key, calls) in
+                ContactCallCount(
+                    name: key,
+                    count: calls.count,
+                    totalDuration: calls.reduce(0) { $0 + $1.duration }
+                )
+            }
+            .sorted { $0.count > $1.count }
+            .prefix(10)
+            .map { $0 }
+
+        // Type distribution
+        let typeGroups = Dictionary(grouping: filtered, by: { $0.callType })
+        let typeDistribution: [(label: String, count: Int, color: String)] = [
+            (label: "Phone", count: typeGroups[.phone]?.count ?? 0, color: "blue"),
+            (label: "FaceTime Video", count: typeGroups[.faceTimeVideo]?.count ?? 0, color: "purple"),
+            (label: "FaceTime Audio", count: typeGroups[.faceTimeAudio]?.count ?? 0, color: "teal"),
+        ].filter { $0.count > 0 }
+
+        // Hourly heatmap
+        let cal = Calendar.current
+        var heatmap: [String: Int] = [:]
+        for record in filtered {
+            let components = cal.dateComponents([.weekday, .hour], from: record.date)
+            let key = "\(components.weekday ?? 1)-\(components.hour ?? 0)"
+            heatmap[key, default: 0] += 1
+        }
+        let hourlyCells = heatmap.map { key, count -> HourlyCell in
+            let parts = key.split(separator: "-").compactMap { Int($0) }
+            return HourlyCell(weekday: parts[0], hour: parts[1], count: count)
+        }
+
+        return AnalyticsData(
+            totalCalls: total,
+            totalDuration: totalDuration,
+            uniqueContacts: uniqueContacts,
+            missedCallCount: missed,
+            missedCallRate: total > 0 ? Double(missed) / Double(total) : 0,
+            incomingCount: incoming,
+            outgoingCount: outgoing,
+            avgCallDuration: avgDuration,
+            dailyCounts: dailyCounts,
+            topContacts: Array(topContacts),
+            typeDistribution: typeDistribution,
+            hourlyCells: hourlyCells
+        )
+    }
+
+    private static func computeDailyCounts(_ records: [CallRecord], timeRange: TimeRange) -> [DailyCallCount] {
+        let cal = Calendar.current
+        var counts: [Date: Int] = [:]
+        for record in records {
+            let day = cal.startOfDay(for: record.date)
+            counts[day, default: 0] += 1
+        }
+
+        // Fill in zero-count days for the range
+        var result: [DailyCallCount] = []
+        if let startDate = timeRange.startDate() {
+            var current = cal.startOfDay(for: startDate)
+            let end = cal.startOfDay(for: Date())
+            while current <= end {
+                result.append(DailyCallCount(id: current, date: current, count: counts[current] ?? 0))
+                current = cal.date(byAdding: .day, value: 1, to: current) ?? current
+            }
+        } else {
+            result = counts.sorted { $0.key < $1.key }
+                .map { DailyCallCount(id: $0.key, date: $0.key, count: $0.value) }
+        }
+        return result
+    }
+}

--- a/CallLogCleaner/Views/AnalyticsDashboardView.swift
+++ b/CallLogCleaner/Views/AnalyticsDashboardView.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+import Charts
+
+struct AnalyticsDashboardView: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    private var data: AnalyticsData? { viewModel.analyticsData }
+
+    var body: some View {
+        ScrollView {
+            if let data = data {
+                VStack(alignment: .leading, spacing: Spacing.xl) {
+                    // Time range picker
+                    HStack {
+                        Text("Analytics")
+                            .font(.appTitle.bold())
+                        Spacer()
+                        Picker("", selection: Binding(
+                            get: { viewModel.analyticsTimeRange },
+                            set: { viewModel.updateAnalyticsRange($0) }
+                        )) {
+                            ForEach(TimeRange.allCases) { range in
+                                Text(range.rawValue).tag(range)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 340)
+                    }
+                    .padding(.bottom, Spacing.xs)
+
+                    // Summary stat cards
+                    LazyVGrid(columns: [
+                        GridItem(.flexible()), GridItem(.flexible()),
+                        GridItem(.flexible()), GridItem(.flexible())
+                    ], spacing: Spacing.md) {
+                        StatCard(
+                            title: "Total Calls",
+                            value: "\(data.totalCalls)",
+                            subtitle: "\(data.incomingCount) in / \(data.outgoingCount) out",
+                            icon: "phone.fill",
+                            color: .appPrimary
+                        )
+                        StatCard(
+                            title: "Total Duration",
+                            value: data.formattedTotalDuration,
+                            subtitle: "Avg \(data.formattedAvgDuration)",
+                            icon: "clock.fill",
+                            color: .callFaceTimeAudio
+                        )
+                        StatCard(
+                            title: "Unique Contacts",
+                            value: "\(data.uniqueContacts)",
+                            subtitle: nil,
+                            icon: "person.2.fill",
+                            color: .callFaceTimeVideo
+                        )
+                        StatCard(
+                            title: "Missed Calls",
+                            value: "\(data.missedCallCount)",
+                            subtitle: String(format: "%.0f%% miss rate", data.missedCallRate * 100),
+                            icon: "phone.down.fill",
+                            color: .appDanger
+                        )
+                    }
+
+                    // Call activity over time
+                    if !data.dailyCounts.isEmpty {
+                        callActivityChart(data.dailyCounts)
+                    }
+
+                    // Two-column row
+                    HStack(alignment: .top, spacing: Spacing.lg) {
+                        if !data.topContacts.isEmpty {
+                            topContactsChart(data.topContacts)
+                                .frame(maxWidth: .infinity)
+                        }
+                        if !data.typeDistribution.isEmpty {
+                            typeDistributionChart(data.typeDistribution)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+
+                    // Heatmap
+                    if !data.hourlyCells.isEmpty {
+                        heatmapView(data.hourlyCells)
+                    }
+
+                    Spacer(minLength: Spacing.xxl)
+                }
+                .padding(Spacing.xl)
+            } else {
+                EmptyStateView(
+                    icon: "chart.bar.xaxis",
+                    title: "No Analytics",
+                    message: "Analytics will appear once call records are loaded.",
+                    color: .appPrimary
+                )
+            }
+        }
+    }
+
+    // MARK: - Call Activity Chart
+
+    private func callActivityChart(_ counts: [DailyCallCount]) -> some View {
+        ChartCard(title: "Call Activity", subtitle: "\(viewModel.analyticsTimeRange.rawValue)") {
+            Chart(counts) { item in
+                AreaMark(
+                    x: .value("Date", item.date, unit: .day),
+                    y: .value("Calls", item.count)
+                )
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [Color.appPrimary.opacity(0.3), Color.appPrimary.opacity(0.03)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .interpolationMethod(.catmullRom)
+
+                LineMark(
+                    x: .value("Date", item.date, unit: .day),
+                    y: .value("Calls", item.count)
+                )
+                .foregroundStyle(Color.appPrimary)
+                .lineStyle(StrokeStyle(lineWidth: 2))
+                .interpolationMethod(.catmullRom)
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day, count: strideCount(for: counts.count))) { _ in
+                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [3]))
+                        .foregroundStyle(Color.primary.opacity(0.1))
+                    AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        .font(.appCaption2)
+                }
+            }
+            .chartYAxis {
+                AxisMarks { value in
+                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [3]))
+                        .foregroundStyle(Color.primary.opacity(0.1))
+                    AxisValueLabel()
+                        .font(.appCaption2)
+                }
+            }
+            .frame(height: 180)
+        }
+    }
+
+    private func strideCount(for total: Int) -> Int {
+        if total <= 14 { return 1 }
+        if total <= 45 { return 7 }
+        return 14
+    }
+
+    // MARK: - Top Contacts Chart
+
+    private func topContactsChart(_ contacts: [ContactCallCount]) -> some View {
+        let top = Array(contacts.prefix(8))
+        return ChartCard(title: "Top Contacts", subtitle: "By call count") {
+            Chart(top) { contact in
+                BarMark(
+                    x: .value("Calls", contact.count),
+                    y: .value("Contact", contact.name)
+                )
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [Color.appPrimary, Color.appPrimary.opacity(0.6)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .cornerRadius(Radius.xs)
+                .annotation(position: .trailing, alignment: .leading) {
+                    Text("\(contact.count)")
+                        .font(.appCaption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .chartXAxis(.hidden)
+            .chartYAxis {
+                AxisMarks { _ in
+                    AxisValueLabel()
+                        .font(.appCaption2)
+                }
+            }
+            .frame(height: max(180, CGFloat(top.count) * 28))
+        }
+    }
+
+    // MARK: - Type Distribution
+
+    private func typeDistributionChart(_ distribution: [(label: String, count: Int, color: String)]) -> some View {
+        let total = distribution.reduce(0) { $0 + $1.count }
+        return ChartCard(title: "Call Types", subtitle: "Distribution") {
+            VStack(spacing: Spacing.lg) {
+                // Custom donut chart (compatible with macOS 13)
+                DonutChartView(segments: distribution.map { (colorForType($0.label), Double($0.count)) })
+                    .frame(height: 140)
+
+                // Legend
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    ForEach(distribution, id: \.label) { item in
+                        HStack(spacing: Spacing.sm) {
+                            Circle()
+                                .fill(colorForType(item.label))
+                                .frame(width: 8, height: 8)
+                            Text(item.label)
+                                .font(.appCaption)
+                            Spacer()
+                            Text("\(item.count)")
+                                .font(.appCaption.weight(.semibold))
+                            Text(String(format: "%.0f%%", Double(item.count) / Double(total) * 100))
+                                .font(.appCaption2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func colorForType(_ label: String) -> Color {
+        switch label {
+        case "Phone":          return .callPhone
+        case "FaceTime Video": return .callFaceTimeVideo
+        case "FaceTime Audio": return .callFaceTimeAudio
+        default:               return .secondary
+        }
+    }
+
+    // MARK: - Heatmap
+
+    private func heatmapView(_ cells: [HourlyCell]) -> some View {
+        let maxCount = cells.map(\.count).max() ?? 1
+        let hours = Array(0..<24)
+        let weekdays = [1, 2, 3, 4, 5, 6, 7]
+        let dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+        return ChartCard(title: "Call Heatmap", subtitle: "Calls by hour and day of week") {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                // Hour labels
+                HStack(spacing: 2) {
+                    Text("").frame(width: 32)
+                    ForEach(hours, id: \.self) { hour in
+                        Text(hour % 6 == 0 ? "\(hour)" : "")
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+
+                // Grid
+                ForEach(weekdays.indices, id: \.self) { dayIdx in
+                    let weekday = weekdays[dayIdx]
+                    HStack(spacing: 2) {
+                        Text(dayLabels[dayIdx])
+                            .font(.system(size: 9))
+                            .foregroundColor(.secondary)
+                            .frame(width: 32, alignment: .leading)
+                        ForEach(hours, id: \.self) { hour in
+                            let count = cells.first(where: { $0.weekday == weekday && $0.hour == hour })?.count ?? 0
+                            let intensity = maxCount > 0 ? Double(count) / Double(maxCount) : 0
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(heatColor(intensity: intensity))
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 16)
+                                .help("\(dayLabels[dayIdx]) \(hour):00 — \(count) calls")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func heatColor(intensity: Double) -> Color {
+        if intensity == 0 { return Color.primary.opacity(0.05) }
+        return Color.appPrimary.opacity(0.12 + intensity * 0.88)
+    }
+}


### PR DESCRIPTION
## Summary
- `AnalyticsEngine` — pure computation service that produces `AnalyticsData` from any `[CallRecord]` slice, filtered by `TimeRange`
- `AnalyticsDashboardView` — full scrollable dashboard: 4-stat header, activity area/line chart, top-contacts bar chart, call-type donut chart, hour×weekday heatmap

## Charts Used
| Chart | API | macOS Req |
|-------|-----|-----------|
| Call activity over time | `AreaMark` + `LineMark` | 13.0 ✓ |
| Top contacts | `BarMark` | 13.0 ✓ |
| Call type distribution | `DonutChartView` (custom Path) | 13.0 ✓ |
| Hour × weekday heatmap | SwiftUI `RoundedRectangle` grid | 13.0 ✓ |

`SectorMark` (native pie/donut) was intentionally avoided — it requires macOS 14.0.

## Heatmap Details
- 7 rows (Sun–Sat) × 24 columns (0–23h)
- Cell colour: `Color.appPrimary.opacity(0.12 + intensity * 0.88)` where `intensity = count / maxCount`
- Empty cells: `Color.primary.opacity(0.05)`
- Tooltip via `.help()` modifier: "Tue 14:00 — 3 calls"

## Test plan
- [ ] `AnalyticsEngine.compute` with empty array returns zero-value `AnalyticsData`
- [ ] `TimeRange.week.startDate()` returns date 7 days ago
- [ ] Dashboard renders all 4 sections with 100 sample records
- [ ] Heatmap cells show correct intensity for peak-hour data
- [ ] Time-range picker updates `analyticsData` when changed

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)